### PR TITLE
[SELS TASK] Bugfix Admin Edit Category Backend Validation

### DIFF
--- a/backend/app/Http/Controllers/Admin/AdminQuizController.php
+++ b/backend/app/Http/Controllers/Admin/AdminQuizController.php
@@ -65,10 +65,16 @@ class AdminQuizController extends Controller
      */
      public function updateAdminQuiz(Quiz $quiz, Request $request)
     {
-        $attributes = $request->validate([
-            'title' => 'required',
-            'description' => 'required',
+        $validator = Validator::make($request->all(), [
+            'title' => ['required'],
+            'description' => ['required'],
         ]);
+
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 422);
+        }
+
+        $attributes = $validator->validated();
 
         $quiz->update($attributes);
 

--- a/frontend/src/Pages/components/AdminCategories/EditCategory.tsx
+++ b/frontend/src/Pages/components/AdminCategories/EditCategory.tsx
@@ -44,7 +44,6 @@ const EditCategory = () => {
                 placeholder="Title"
                 {...register("title", {
                   required: "Title is required",
-                  min: 100,
                 })}
               />
               {errors.title && (
@@ -57,7 +56,6 @@ const EditCategory = () => {
                 placeholder="Description"
                 {...register("description", {
                   required: "Description is required",
-                  min: 250,
                 })}
               />
               {errors.description && (


### PR DESCRIPTION
### Asana Link
https://app.asana.com/0/1201308373374092/board

### Commands
`cd backend > php artisan migrate:fresh > php artisan db:seed --class=QuizzesSeeder > php artisan db:seed --class=AdminSeeder > php artisan db:seed --class=UserSeeder > php artisan db:seed --class=QuizLogSeeder > php artisan db:seed --class=FollowSeeder > php artisan serve`

`cd frontend > npm start`

### Pre-Conditions

- Should sign in a user http://localhost:3000/ from the user seeder users table, copy it's **email** and with its default password as **password**  in the frontend
- Should run http://localhost:3000/admin/edit-category/:quizId

### Expected Output

- Should not have a CORS error when title or description is empty
- Should respond a 422 code if title or description is empty

### Screenshot

### Bug:
![Screenshot 2021-11-26 180503](https://user-images.githubusercontent.com/92574920/143564317-98e4215a-872f-411a-966f-a89ee9b44f3e.png)

### Fixed:
![Screenshot 2021-11-26 180645](https://user-images.githubusercontent.com/92574920/143564343-0af696ab-f801-49cf-9421-ebbf052c9b6c.png)