### PR TITLE
[SELS TASK] Bugfix Admin Add Question and Choices Backend Validation

### DIFF
--- a/backend/app/Http/Controllers/Admin/AdminQuizController.php
+++ b/backend/app/Http/Controllers/Admin/AdminQuizController.php
@@ -100,13 +100,18 @@ class AdminQuizController extends Controller
      */
      public function storeAdminQuizQuestion(Request $request, Quiz $quiz)
     {
-
-        $attributes = $request->validate([
-            'word' => 'required',
-            'choices' => 'required|array|min:4',
-            'choices.*.value' => 'required|string',
-            'choices.*.is_correct' => 'required|boolean',
+        $validator = Validator::make($request->all(), [
+            'word' => ['required'],
+            'choices' => ['required', 'array', 'min:4'],
+            'choices.*.value' => ['required', 'string'],
+            'choices.*.is_correct' => ['required', 'boolean'],
         ]);
+
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 422);
+        }
+
+        $attributes = $validator->validated();
 
         $question = Question::create([
             'word' => $attributes['word'],

--- a/frontend/src/Pages/components/AdminCategories/AddCategoryWords.tsx
+++ b/frontend/src/Pages/components/AdminCategories/AddCategoryWords.tsx
@@ -32,7 +32,6 @@ const AddCategoryWords = () => {
                 placeholder="Word"
                 {...register("word", {
                   required: "Word is required",
-                  min: 100,
                 })}
               />
               {errors.word && (
@@ -47,7 +46,6 @@ const AddCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[0].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>
@@ -68,7 +66,6 @@ const AddCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[1].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>
@@ -89,7 +86,6 @@ const AddCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[2].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>
@@ -110,7 +106,6 @@ const AddCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[3].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>


### PR DESCRIPTION
### Asana Link
https://app.asana.com/0/1201308373374092/board

### Commands
`cd backend > php artisan migrate:fresh > php artisan db:seed --class=QuizzesSeeder > php artisan db:seed --class=AdminSeeder > php artisan db:seed --class=UserSeeder > php artisan db:seed --class=QuizLogSeeder > php artisan db:seed --class=FollowSeeder > php artisan serve`

`cd frontend > npm start`

### Pre-Conditions

- Should sign in a user http://localhost:3000/ from the user seeder users table, copy it's **email** and with its default password as **password**  in the frontend
- Should run http://localhost:3000/admin/categories/:quizId/words

### Expected Output

- Should not have a CORS error when word and choices is empty
- Should respond a 422 code if word and choices is empty

### Screenshot

### Bug:
![Screenshot 2021-11-26 182255](https://user-images.githubusercontent.com/92574920/143567991-2e5c1ee3-d97b-461a-b376-951b966d7424.png)

### Fixed:
![Screenshot 2021-11-26 183631](https://user-images.githubusercontent.com/92574920/143568008-d45655d7-bcb6-4e89-940d-5a24dc2c5eb8.png)