### PR TITLE
[SELS TASK] Bugfix Admin Edit Question and Choices Backend Validation

### DIFF
--- a/backend/app/Http/Controllers/Admin/AdminQuizController.php
+++ b/backend/app/Http/Controllers/Admin/AdminQuizController.php
@@ -100,13 +100,18 @@ class AdminQuizController extends Controller
      */
      public function storeAdminQuizQuestion(Request $request, Quiz $quiz)
     {
-
-        $attributes = $request->validate([
-            'word' => 'required',
-            'choices' => 'required|array|min:4',
-            'choices.*.value' => 'required|string',
-            'choices.*.is_correct' => 'required|boolean',
+        $validator = Validator::make($request->all(), [
+            'word' => ['required'],
+            'choices' => ['required', 'array', 'min:4'],
+            'choices.*.value' => ['required', 'string'],
+            'choices.*.is_correct' => ['required', 'boolean'],
         ]);
+
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 422);
+        }
+
+        $attributes = $validator->validated();
 
         $question = Question::create([
             'word' => $attributes['word'],
@@ -174,12 +179,18 @@ class AdminQuizController extends Controller
      */
      public function updateAdminQuizQuestion(Question $question, Request $request)
     {
-        $attributes = $request->validate([
-            'word' => 'required',
-            'choices' => 'required|array|min:4',
-            'choices.*.value' => 'required|string',
-            'choices.*.is_correct' => 'required|boolean',
+        $validator = Validator::make($request->all(), [
+            'word' => ['required'],
+            'choices' => ['required', 'array', 'min:4'],
+            'choices.*.value' => ['required', 'string'],
+            'choices.*.is_correct' => ['required', 'boolean'],
         ]);
+
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 422);
+        }
+
+        $attributes = $validator->validated();
 
         $question->update([
             'word' => $attributes['word'],

--- a/frontend/src/Pages/components/AdminCategories/AddCategoryWords.tsx
+++ b/frontend/src/Pages/components/AdminCategories/AddCategoryWords.tsx
@@ -32,7 +32,6 @@ const AddCategoryWords = () => {
                 placeholder="Word"
                 {...register("word", {
                   required: "Word is required",
-                  min: 100,
                 })}
               />
               {errors.word && (
@@ -47,7 +46,6 @@ const AddCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[0].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>
@@ -68,7 +66,6 @@ const AddCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[1].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>
@@ -89,7 +86,6 @@ const AddCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[2].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>
@@ -110,7 +106,6 @@ const AddCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[3].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>

--- a/frontend/src/Pages/components/AdminCategories/EditCategoryWords.tsx
+++ b/frontend/src/Pages/components/AdminCategories/EditCategoryWords.tsx
@@ -69,7 +69,6 @@ const EditCategoryWords = () => {
                 placeholder="Word"
                 {...register("word", {
                   required: "Word is required",
-                  min: 100,
                 })}
               />
               {errors.word && (
@@ -84,7 +83,6 @@ const EditCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[0].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>
@@ -105,7 +103,6 @@ const EditCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[1].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>
@@ -126,7 +123,6 @@ const EditCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[2].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>
@@ -147,7 +143,6 @@ const EditCategoryWords = () => {
                 placeholder="Choice"
                 {...register("choices[3].value", {
                   required: "Choice is required",
-                  min: 100,
                 })}
               />
             </div>


### PR DESCRIPTION
### Asana Link
https://app.asana.com/0/1201308373374092/board

### Commands
`cd backend > php artisan migrate:fresh > php artisan db:seed --class=QuizzesSeeder > php artisan db:seed --class=AdminSeeder > php artisan db:seed --class=UserSeeder > php artisan db:seed --class=QuizLogSeeder > php artisan db:seed --class=FollowSeeder > php artisan serve`

`cd frontend > npm start`

### Pre-Conditions

- Should sign in an admin http://localhost:3000/ from the user seeder users table, copy it's **email** and with its default password as **password**  in the frontend
- Should run http://localhost:3000/admin/categories/:quizId/words/:questionId

### Expected Output

- Should not have a CORS error when word and choices is empty
- Should respond a 422 code if word and choices is empty

### Screenshot

### Bug:
![Screenshot 2021-11-29 094058](https://user-images.githubusercontent.com/92574920/143796628-8d88f4ce-ad3b-43c5-a99a-a740ec41b568.png)

### Fixed:
![Screenshot 2021-11-29 094303](https://user-images.githubusercontent.com/92574920/143796642-b563af5b-25ae-4fd2-85e5-9fc4c2043bc0.png)