### PR TITLE
[SELS TASK] Bugfix Admin Sign In Backend Validation

### DIFF
--- a/backend/app/Http/Controllers/Auth/AdminAuthenticationController.php
+++ b/backend/app/Http/Controllers/Auth/AdminAuthenticationController.php
@@ -7,15 +7,22 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
 
 class AdminAuthenticationController extends Controller
 {
     public function signinAdmin(Request $request)
     {
-        $attributes = $request->validate([
-            'email' => 'required|email',
-            'password' => 'required',
+        $validator = Validator::make($request->all(), [
+            'email' => ['required', 'email'],
+            'password' => ['required'],
         ]);
+
+        if ($validator->fails()) {
+            return response()->json($validator->errors(), 422);
+        }
+
+        $attributes = $validator->validated();
 
         $user = User::where('email', $attributes['email'])
                     ->where('isAdmin', 1)


### PR DESCRIPTION
### Asana Link
https://app.asana.com/0/1201308373374092/board

### Commands
`cd backend > php artisan migrate:fresh > php artisan db:seed --class=QuizzesSeeder > php artisan db:seed --class=AdminSeeder > php artisan db:seed --class=UserSeeder > php artisan db:seed --class=QuizLogSeeder > php artisan db:seed --class=FollowSeeder > php artisan serve`

`cd frontend > npm start`

### Pre-Conditions

- Should sign in an admin http://localhost:3000/ from the user seeder users table, copy it's **email** and with its default password as **password**  in the frontend
- Should run http://localhost:3000/admin

### Expected Output

- Should not have a CORS error when email and password is empty
- Should respond a 422 code if email and password is empty

### Screenshot

### Bug:
![Screenshot 2021-11-29 100710](https://user-images.githubusercontent.com/92574920/143798261-41ef7061-e091-4e64-870f-64bc456e7e99.png)

### Fixed:
![Screenshot 2021-11-29 100750](https://user-images.githubusercontent.com/92574920/143798269-779e9e29-df7b-4d4e-b0ed-17f8409afdd4.png)